### PR TITLE
fix pip install error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,4 +40,4 @@ pg8000
 pgvector
 json_repair
 rich
-psycopg2
+psycopg2-binary


### PR DESCRIPTION
Replace the psycopg2 library with psycopg2-binary because psycopg2 installation requires a local installation of postgresql.