### PR TITLE
fix: prevent duplicate inner_thoughts in required

### DIFF
--- a/mirix/llm_api/google_ai.py
+++ b/mirix/llm_api/google_ai.py
@@ -230,7 +230,8 @@ def convert_tools_to_google_ai_format(tools: List[Tool], inner_thoughts_in_kwarg
                 "type": "STRING",
                 "description": INNER_THOUGHTS_KWARG_DESCRIPTION,
             }
-            func["parameters"]["required"].append(INNER_THOUGHTS_KWARG)
+            if INNER_THOUGHTS_KWARG not in func["parameters"]["required"]:
+                func["parameters"]["required"].append(INNER_THOUGHTS_KWARG)
 
     return [{"functionDeclarations": function_list}]
 


### PR DESCRIPTION
Running convert_tools_to_google_ai_format multiple times
can cause 'inner_thoughts' to be added repeatedly to 'required'.
This fix ensures that duplicates are prevented.

Note: Multiple executions may occur when the Gemini model is overloaded and triggers retries.