### PR TITLE
Fix the update_at timezone bug

### DIFF
--- a/mirix/schemas/file.py
+++ b/mirix/schemas/file.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from pydantic import Field
 
+from mirix.helpers.datetime_helpers import get_utc_time
 from mirix.schemas.mirix_base import MirixBase
 
 
@@ -48,9 +49,9 @@ class FileMetadata(FileMetadataBase):
 
     # orm metadata, optional fields
     created_at: Optional[datetime] = Field(
-        default_factory=datetime.utcnow, description="The creation date of the file."
+        default_factory=get_utc_time, description="The creation date of the file."
     )
     updated_at: Optional[datetime] = Field(
-        default_factory=datetime.utcnow, description="The update date of the file."
+        default_factory=get_utc_time, description="The update date of the file."
     )
     is_deleted: bool = Field(False, description="Whether this file is deleted or not.")

--- a/mirix/schemas/user.py
+++ b/mirix/schemas/user.py
@@ -4,6 +4,7 @@ import uuid
 
 from pydantic import Field
 
+from mirix.helpers.datetime_helpers import get_utc_time
 from mirix.schemas.mirix_base import MirixBase
 from mirix.services.organization_manager import OrganizationManager
 
@@ -40,10 +41,10 @@ class User(UserBase):
     status: str = Field("active", description="Whether the user is active or not.")
     timezone: str = Field(..., description="The timezone of the user.")
     created_at: Optional[datetime] = Field(
-        default_factory=datetime.utcnow, description="The creation date of the user."
+        default_factory=get_utc_time, description="The creation date of the user."
     )
     updated_at: Optional[datetime] = Field(
-        default_factory=datetime.utcnow, description="The update date of the user."
+        default_factory=get_utc_time, description="The update date of the user."
     )
     is_deleted: bool = Field(False, description="Whether this user is deleted or not.")
 

--- a/mirix/services/procedural_memory_manager.py
+++ b/mirix/services/procedural_memory_manager.py
@@ -482,9 +482,9 @@ class ProceduralMemoryManager:
             )
             update_data = item_update.model_dump(exclude_unset=True)
             for k, v in update_data.items():
-                if k not in ["id", "updated_at"]:  # or allow updated_at if you want
+                if k not in ["id", "updated_at"]:  # Exclude updated_at - handled by update() method
                     setattr(item, k, v)
-            item.updated_at = item_update.updated_at  # or get_utc_time
+            # updated_at is automatically set to current UTC time by item.update()
             item.update(session, actor=actor)
             return item.to_pydantic()
 

--- a/mirix/services/resource_memory_manager.py
+++ b/mirix/services/resource_memory_manager.py
@@ -439,9 +439,9 @@ class ResourceMemoryManager:
             )
             update_data = item_update.model_dump(exclude_unset=True)
             for k, v in update_data.items():
-                if k not in ["id", "updated_at"]:
+                if k not in ["id", "updated_at"]:  # Exclude updated_at - handled by update() method
                     setattr(item, k, v)
-            item.updated_at = item_update.updated_at
+            # updated_at is automatically set to current UTC time by item.update()
             item.update(session, actor=actor)
             return item.to_pydantic()
 

--- a/mirix/services/semantic_memory_manager.py
+++ b/mirix/services/semantic_memory_manager.py
@@ -496,9 +496,9 @@ class SemanticMemoryManager:
             )
             update_data = item_update.model_dump(exclude_unset=True)
             for k, v in update_data.items():
-                if k not in ["id", "updated_at"]:
+                if k not in ["id", "updated_at"]:  # Exclude updated_at - handled by update() method
                     setattr(item, k, v)
-            item.updated_at = item_update.updated_at
+            # updated_at is automatically set to current UTC time by item.update()
             item.update(session, actor=actor)
             return item.to_pydantic()
 


### PR DESCRIPTION
ORIGINAL ISSUE:

Across multiple memory types, there appears to be a bug with the updated_at column values. On initial creation, updated_at is accurate. However, if the row is later updated by a memory manager, the timestamp is inaccurate. The row will be updated with a timestamp value as if the date is UTC, but the timezone offset will show the local timezone offset, not UTC. 

FIX:

Make sure the update_at sets time with UTC datatime with UTC timezone.

