### PR TITLE
Update all sample clients to use Gemini

### DIFF
--- a/run_client.py
+++ b/run_client.py
@@ -35,8 +35,8 @@ def main():
     )
 
     client.initialize_meta_agent(
-        # config_path="mirix/configs/examples/mirix_gemini.yaml",
-        config_path="mirix/configs/examples/mirix_openai.yaml",
+        config_path="mirix/configs/examples/mirix_gemini.yaml",
+        # config_path="mirix/configs/examples/mirix_openai.yaml",
         update_agents=False
     )
 

--- a/samples/add_test_memory.py
+++ b/samples/add_test_memory.py
@@ -299,7 +299,7 @@ def main():
     try:
         # Compute config path relative to project root (parent of samples/)
         project_root = Path(__file__).parent.parent
-        config_path = project_root / "mirix" / "configs" / "examples" / "mirix_openai.yaml"
+        config_path = project_root / "mirix" / "configs" / "examples" / "mirix_gemini.yaml"
         
         client.initialize_meta_agent(
             config_path=str(config_path),

--- a/samples/langgraph_integration.py
+++ b/samples/langgraph_integration.py
@@ -45,7 +45,7 @@ user_id = "demo-user"
 org_id = "demo-org"
 
 # Build absolute path to config file (since we're in samples/ subdirectory)
-config_path = os.path.join(mirix_root, "mirix/configs/examples/mirix_openai.yaml")
+config_path = os.path.join(mirix_root, "mirix/configs/examples/mirix_gemini.yaml")
     
 client = MirixClient(
     api_key=None, # TODO: add authentication later


### PR DESCRIPTION
Update all sample clients to use Gemini, so the test code can use the default Gemini API key. 