### PR TITLE
feat: allow router to be used separately from app

### DIFF
--- a/mirix/server/rest_api.py
+++ b/mirix/server/rest_api.py
@@ -1177,6 +1177,8 @@ def retrieve_memories_by_keywords(
             search_method=search_method,
             limit=limit,
             timezone_str=timezone_str,
+            filter_tags=filter_tags,
+            use_cache=use_cache,
         )
 
         memories["resource"] = {
@@ -1207,6 +1209,8 @@ def retrieve_memories_by_keywords(
             search_method=search_method,
             limit=limit,
             timezone_str=timezone_str,
+            filter_tags=filter_tags,
+            use_cache=use_cache,
         )
 
         memories["procedural"] = {


### PR DESCRIPTION
### Summary
Refactored the REST API to enable the router to be used independently from the FastAPI application. It's still possible to run the entire FastAPI app as a standalone package. However, there is now the option to import the router individually to be included in a different FastAPI application.

### Changes
- Extracted all API endpoints from `app` into a standalone `APIRouter`
- Split `lifespan()` into separate `initialize()` and `cleanup()` functions for manual lifecycle management when using the standalone router. 
- Added public exports: `app`, `router`, `initialize`, `cleanup`

### Benefits
- Router can be included in external FastAPI applications
- Manual control over server lifecycle for advanced integrations
- Fully backward compatible with existing standalone usage

### Usage
Here's how to use the router separately from the app.

```python
from contextlib import asynccontextmanager
from fastapi import FastAPI
from mirix.server.rest_api import router, initialize, cleanup

@asynccontextmanager
async def lifespan(app: FastAPI):
    await initialize()
    yield
    await cleanup()

my_app = FastAPI(lifespan=lifespan)
my_app.include_router(router) # optionally, you can include a prefix here. 
```