### PR TITLE
Unified task/conversation memory via adaptive session_tag routing

### DIFF
--- a/mirix/constants.py
+++ b/mirix/constants.py
@@ -309,6 +309,27 @@ SKILL_TRIGGER_MESSAGE_THRESHOLD = int(
 SKILL_TRIGGER_SESSION_THRESHOLD = int(os.getenv("SKILL_TRIGGER_SESSION_THRESHOLD", "5"))
 
 # ---------------------------------------------------------------------------
+# Adaptive per-session routing (session_tag).
+# ---------------------------------------------------------------------------
+# A session is either a "task" (agentic tool-use rollout; ALFWorld-style) or a
+# "conversation" (chat/dialogue; LOCOMO-style). The tag decides which memory
+# machinery engages:
+#   task         -> procedural/skill distillation (auto_dream mode="procedural")
+#                   fires on the every-N-session batch trigger; the inline
+#                   episodic/semantic extraction is suppressed (task = skill-only).
+#   conversation -> inline episodic/semantic extraction runs as usual; the
+#                   procedural batch trigger does NOT fire (no skills), and
+#                   experience consolidation stays operator-invoked (auto_dream
+#                   mode="experience"), matching how LOCOMO ran it.
+# Callers declare the tag on ingest (AddMemoryRequest.session_tag). Unset falls
+# back to DEFAULT_SESSION_TAG so historical/untagged callers stay LOCOMO-safe
+# (no spurious skill distillation).
+SESSION_TAG_TASK = "task"
+SESSION_TAG_CONVERSATION = "conversation"
+VALID_SESSION_TAGS = (SESSION_TAG_TASK, SESSION_TAG_CONVERSATION)
+DEFAULT_SESSION_TAG = os.getenv("MIRIX_DEFAULT_SESSION_TAG", SESSION_TAG_CONVERSATION)
+
+# ---------------------------------------------------------------------------
 # Bounded, count-driven, quality-aware edit budget (skill evolution).
 #
 # The budget is the MAX number of skill mutations (create+edit) a single

--- a/mirix/functions/function_sets/memory_tools.py
+++ b/mirix/functions/function_sets/memory_tools.py
@@ -1650,9 +1650,21 @@ async def trigger_memory_update(
     # concurrent workers can never double-fire for the same window, and it
     # advances the cursor to the observed MAX(messages.created_at) so the
     # next window cannot skip messages inserted mid-check.
-    from mirix.constants import DEFAULT_ORG_ID, SKILL_TRIGGER_SESSION_THRESHOLD
+    from mirix.constants import (
+        DEFAULT_ORG_ID,
+        DEFAULT_SESSION_TAG,
+        SESSION_TAG_TASK,
+        SKILL_TRIGGER_SESSION_THRESHOLD,
+    )
     from mirix.schemas.agent_trigger_state import TRIGGER_TYPE_PROCEDURAL_SKILL
     from mirix.services.agent_trigger_state_manager import AgentTriggerStateManager
+
+    # Adaptive routing: the session_tag rides on filter_tags (stamped at ingest),
+    # which is set on this agent instance (self.filter_tags). "task" sessions
+    # feed procedural skill distillation; "conversation" sessions never do.
+    session_tag = (getattr(self, "filter_tags", None) or {}).get(
+        "session_tag"
+    ) or DEFAULT_SESSION_TAG
 
     # Messages are stored against the top-level (chat) agent, not the meta
     # agent, so count sessions on the parent when this tool runs inside a
@@ -1670,7 +1682,16 @@ async def trigger_memory_update(
     )
     current_session_id = getattr(self, "_current_step_session_id", None)
 
-    if trigger_user_id is None:
+    if session_tag != SESSION_TAG_TASK:
+        # Adaptive routing: only "task" sessions produce procedural skills.
+        # A "conversation" session (LOCOMO-style dialogue) must NEVER fire the
+        # every-N-session procedural batch trigger; its consolidation is the
+        # operator-invoked experience auto-dream (mode="experience"), never skills.
+        logger.debug(
+            "Skipping procedural session trigger: session_tag=%s (not 'task').",
+            session_tag,
+        )
+    elif trigger_user_id is None:
         # No user scope — we cannot bookkeep a per-user cursor. Skip the
         # auto-trigger rather than silently lumping all users together.
         logger.debug("Skipping session-based procedural trigger: no user on agent.")
@@ -1719,15 +1740,29 @@ async def trigger_memory_update(
     # an accepted input value (a harmless no-op) so existing callers / LLM emissions
     # don't error; it simply no longer dispatches. The procedural_memory_agent
     # registration and infrastructure are retained for the distillation path.
-    filtered_memory_types = [mt for mt in memory_types if mt != "procedural"]
-    if len(filtered_memory_types) != len(memory_types):
-        logger.debug(
-            "Filtered 'procedural' out of trigger_memory_update dispatch "
-            "(procedural memory is produced solely by the distillation path): "
-            "%s -> %s",
-            list(memory_types),
-            filtered_memory_types,
-        )
+    if session_tag == SESSION_TAG_TASK:
+        # Adaptive routing: a "task" session is skill-only. Its conversation turns
+        # feed the procedural distiller (auto_dream mode="procedural"); the inline
+        # episodic/semantic/core/... extraction is intentionally suppressed so a
+        # tool-use rollout does not spend LLM calls building conversational memory
+        # nobody reads.
+        if memory_types:
+            logger.debug(
+                "Suppressing inline memory extraction for task session "
+                "(skill-only): %s -> []",
+                list(memory_types),
+            )
+        filtered_memory_types = []
+    else:
+        filtered_memory_types = [mt for mt in memory_types if mt != "procedural"]
+        if len(filtered_memory_types) != len(memory_types):
+            logger.debug(
+                "Filtered 'procedural' out of trigger_memory_update dispatch "
+                "(procedural memory is produced solely by the distillation path): "
+                "%s -> %s",
+                list(memory_types),
+                filtered_memory_types,
+            )
     memory_types = filtered_memory_types
 
     # De-duplicate memory types while preserving order.

--- a/mirix/orm/conversation_message.py
+++ b/mirix/orm/conversation_message.py
@@ -93,6 +93,17 @@ class ConversationMessage(SqlalchemyBase, OrganizationMixin, UserMixin):
         doc="Set when this session's turns were consumed by a distill round. "
         "NULL = not yet distilled; the rolling barrier reads only NULL sessions.",
     )
+    session_tag: Mapped[Optional[str]] = mapped_column(
+        String,
+        nullable=True,
+        default=None,
+        index=True,
+        doc="Adaptive routing tag for this session: 'task' | 'conversation' | NULL. "
+        "The procedural distiller excludes sessions explicitly tagged "
+        "'conversation' (LOCOMO-style dialogue never becomes a skill); 'task' and "
+        "untagged (NULL, legacy) sessions remain eligible so the gate fails OPEN "
+        "and never silently drops task skill-building.",
+    )
 
     # Indexes mirror the skill_experience pg/sqlite guard pattern: an explicit
     # `is not None` filter (not `filter(None, ...)`) because an un-attached Index

--- a/mirix/server/rest_api.py
+++ b/mirix/server/rest_api.py
@@ -2134,6 +2134,9 @@ class AddMemoryRequest(BaseModel):
     session_id: Optional[str] = (
         None  # Batch-level session id applied to every message in this request
     )
+    session_tag: Optional[str] = (
+        None  # "task" | "conversation"; routes memory machinery. None -> DEFAULT_SESSION_TAG.
+    )
     block_filter_tags: Optional[Dict[str, Any]] = (
         None  # Applied only when blocks are created (e.g. from default template)
     )
@@ -2147,6 +2150,19 @@ class AddMemoryRequest(BaseModel):
     @classmethod
     def _check_session_id(cls, v: Optional[str]) -> Optional[str]:
         return _validate_session_id(v)
+
+    @field_validator("session_tag")
+    @classmethod
+    def _check_session_tag(cls, v: Optional[str]) -> Optional[str]:
+        from mirix.constants import VALID_SESSION_TAGS
+
+        if v is None:
+            return None
+        if v not in VALID_SESSION_TAGS:
+            raise ValueError(
+                f"session_tag must be one of {VALID_SESSION_TAGS}; got {v!r}"
+            )
+        return v
 
     @model_validator(mode="after")
     def _check_session_id_agrees_with_filter_tags(self) -> "AddMemoryRequest":
@@ -2306,12 +2322,15 @@ async def _ingest_session_turns(request, input_messages, client, user_id: str) -
         conversation_turns = _extract_conversation_turns(request.messages)
         if not conversation_turns:
             return
+        from mirix.constants import DEFAULT_SESSION_TAG
+
         await ConversationMessageManager().record_turns(
             session_id=request.session_id,
             user_id=user_id,
             organization_id=owner_org(client),
             turns=conversation_turns,
             actor=client,
+            session_tag=request.session_tag or DEFAULT_SESSION_TAG,
         )
     except Exception:
         logger.exception(
@@ -2414,6 +2433,12 @@ async def add_memory(
     # The model_validator on AddMemoryRequest has already ensured agreement if both were set.
     if request.session_id is not None:
         filter_tags["session_id"] = request.session_id
+
+    # Stamp the resolved session_tag so downstream routing (trigger_memory_update)
+    # and extracted-memory provenance always see it, with or without a session_id.
+    from mirix.constants import DEFAULT_SESSION_TAG
+
+    filter_tags["session_tag"] = request.session_tag or DEFAULT_SESSION_TAG
 
     if request.block_filter_tags is not None and not isinstance(
         request.block_filter_tags, dict
@@ -2533,6 +2558,12 @@ async def add_memory_sync(
     # The AddMemoryRequest model_validator already ensured agreement if both were set.
     if request.session_id is not None:
         filter_tags["session_id"] = request.session_id
+
+    # Stamp the resolved session_tag so downstream routing (trigger_memory_update)
+    # and extracted-memory provenance always see it, with or without a session_id.
+    from mirix.constants import DEFAULT_SESSION_TAG
+
+    filter_tags["session_tag"] = request.session_tag or DEFAULT_SESSION_TAG
 
     if client.write_scope is None:
         raise HTTPException(

--- a/mirix/services/conversation_message_manager.py
+++ b/mirix/services/conversation_message_manager.py
@@ -34,9 +34,9 @@ from __future__ import annotations
 
 import datetime as dt
 from datetime import timedelta
-from typing import List
+from typing import List, Optional
 
-from sqlalchemy import delete, func, select, update
+from sqlalchemy import delete, func, or_, select, update
 
 from mirix.client.utils import get_utc_time
 from mirix.log import get_logger
@@ -85,6 +85,7 @@ class ConversationMessageManager:
         organization_id: str,
         turns: List[dict],
         actor: PydanticClient,
+        session_tag: Optional[str] = None,
     ) -> List[PydanticConversationMessage]:
         """Append `turns` to `session_id`, preserving their given order.
 
@@ -147,6 +148,7 @@ class ConversationMessageManager:
                     organization_id=payload.organization_id,
                     role=payload.role,
                     content=payload.content,
+                    session_tag=session_tag,
                     # +offset microseconds keeps a strict, stable order within
                     # the batch even though they share one transaction.
                     created_at=base + timedelta(microseconds=offset),
@@ -231,6 +233,8 @@ class ConversationMessageManager:
         if limit <= 0:
             return []
 
+        from mirix.constants import SESSION_TAG_CONVERSATION
+
         async with self.session_maker() as session:
             first_ts = func.min(ConversationMessageModel.created_at).label("first_ts")
             # NULL distilled_at on EVERY turn of a session <=> the session is
@@ -250,6 +254,16 @@ class ConversationMessageManager:
                     ConversationMessageModel.organization_id == organization_id,
                     ConversationMessageModel.user_id == user_id,
                     ConversationMessageModel.is_deleted.is_(False),
+                    # Adaptive-routing hard gate: never distill sessions EXPLICITLY
+                    # tagged 'conversation' (LOCOMO-style dialogue must never become
+                    # a skill). Fail OPEN — 'task' and untagged (NULL, legacy)
+                    # sessions stay eligible so a missing/failed tag can never
+                    # silently zero out task skill-building.
+                    or_(
+                        ConversationMessageModel.session_tag
+                        != SESSION_TAG_CONVERSATION,
+                        ConversationMessageModel.session_tag.is_(None),
+                    ),
                 )
                 .group_by(ConversationMessageModel.session_id)
                 .order_by(first_ts.asc())

--- a/scripts/migrate_add_conversation_message_session_tag.sql
+++ b/scripts/migrate_add_conversation_message_session_tag.sql
@@ -1,0 +1,32 @@
+-- Migration: add nullable session_tag column + index on conversation_message.
+-- Run once on existing databases. New databases get this via SQLAlchemy create_all.
+--
+-- session_tag drives adaptive per-session memory routing:
+--   'task'         -> procedural/skill distillation (auto_dream mode="procedural")
+--   'conversation' -> inline episodic/semantic extraction; NO skill distillation
+--   NULL (legacy)  -> treated as eligible by the distiller (fail-open), so this
+--                     backfill-free migration never silently drops skill-building
+--                     on pre-existing task data.
+--
+-- The column is nullable with no default: existing rows keep NULL, and the
+-- distiller gate (list_sealed_undistilled_sessions) excludes only rows
+-- EXPLICITLY tagged 'conversation'. No row rewrite, no backfill required.
+
+-- Idempotent: safe to re-run.
+BEGIN;
+
+ALTER TABLE conversation_message
+    ADD COLUMN IF NOT EXISTS session_tag VARCHAR;
+
+COMMIT;
+
+-- Index the routing tag so the distiller's sealed-session enumeration can filter
+-- on it cheaply. CREATE INDEX CONCURRENTLY cannot run inside a transaction, so
+-- run this line OUTSIDE a transaction block (not via psql -1):
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_conversation_message_session_tag
+--       ON conversation_message (session_tag);
+--
+-- On a fresh/small database the transactional form is fine:
+CREATE INDEX IF NOT EXISTS ix_conversation_message_session_tag
+    ON conversation_message (session_tag);


### PR DESCRIPTION
# Unified task/conversation memory via adaptive `session_tag` routing

## What & why

MIRIX has six memory components, but until now **every ingested session ran the
full memory machinery** regardless of what kind of input it was. A tool-use
rollout (where skills matter) and a chat conversation (where episodic/semantic
facts matter) were treated identically — wasting LLM calls and, worse, letting
conversation traffic trigger skill distillation that produces nothing useful.

This PR adds a single **`session_tag`** on ingest so the two regimes coexist in
one framework, each engaging only the memory it needs:

| | `task` (e.g. ALFWorld rollouts) | `conversation` (e.g. LOCOMO dialogue) |
|---|---|---|
| Procedural / **skill** distillation | ✅ `auto_dream(mode="procedural")` | ❌ never |
| Inline episodic / semantic extraction | ❌ suppressed (skill-only) | ✅ as before |
| Experience consolidation | — | operator-invoked `auto_dream(mode="experience")` |

The caller declares the tag on ingest (`AddMemoryRequest.session_tag`). Unset
falls back to `DEFAULT_SESSION_TAG="conversation"`, so existing/untagged callers
keep their current behaviour and never get spurious skill distillation.

```python
# task caller (skill-building)
POST /memory/add_sync  { ..., "session_tag": "task" }
# conversation caller (default) — tag optional
POST /memory/add_sync  { ..., "session_tag": "conversation" }
```

## How it works (minimal surface)

- The tag rides on `filter_tags`, which is already stamped at ingest, set on the
  agent instance (`self.filter_tags`), and read in `trigger_memory_update` — so
  **no `Message`-schema or `agent.step` change is required.**
- The batch procedural trigger fires **only** for `task` sessions.
- For `task`, `trigger_memory_update` suppresses inline episodic/semantic
  dispatch (the rollout's turns still feed the skill distiller via the
  conversation store).
- The distiller's sealed-session gate (`list_sealed_undistilled_sessions`) is
  **fail-open**: it excludes only sessions *explicitly* tagged `conversation`.
  A missing/failed tag therefore can never silently zero out task skill-building.

## Changes

- `constants.py` — `SESSION_TAG_TASK` / `SESSION_TAG_CONVERSATION` / `DEFAULT_SESSION_TAG`.
- `server/rest_api.py` — `AddMemoryRequest.session_tag` + validator; both add
  flows stamp `filter_tags["session_tag"]` and pass it to the conversation store.
- `orm/conversation_message.py` — nullable `session_tag` column (+ index).
- `services/conversation_message_manager.py` — persist the tag; fail-open
  distiller gate.
- `functions/function_sets/memory_tools.py` — read the tag; route batch trigger
  and inline extraction.
- `scripts/migrate_add_conversation_message_session_tag.sql` — one-time column
  add for existing DBs (nullable, no backfill; new DBs get it via `create_all`).

## Tested — scores on both regimes

Measured on Azure OpenAI (agent policy gpt-5.2, memory gpt-4.1-mini unless noted).

**Conversation — LOCOMO-10** (routing must not regress dialogue memory):

| | Overall | Single | Multi | Open | Temporal |
|---|---|---|---|---|---|
| with routing | **81.23%** | 83.1 | 82.6 | 68.8 | 78.8 |
| reference | 81.3% | 83.6 | 79.4 | 71.9 | 79.8 |

→ **zero regression** (−0.07 overall; per-category within LLM noise). `conversation`
sessions extract episodic/semantic normally; the procedural trigger stays off
(LOCOMO QA never reads procedural).

**Task — ALFWorld** (SkillOpt split, frozen test = 134; gpt-5.2 agent):

| skill distiller + curator | test success | vs baseline 52.2% |
|---|---|---|
| none (baseline) | 52.2% (70/134) | — |
| gpt-4.1-mini | 68.7 / 56.7 / 48.5% (high variance) | −3.7 … +16.5 |
| **gpt-5.2 (full)** | **68.7% (92/134)** | **+16.5** |

→ `task` routing builds + retrieves skills correctly; with a strong distiller the
skills capture real failure modes (anti-loop / disambiguation / bounded-search)
and lift success **+16.5** over the no-skill baseline.

## Migration / compatibility

Backward compatible. Existing rows keep `session_tag = NULL` and remain
skill-eligible (fail-open). Run
`scripts/migrate_add_conversation_message_session_tag.sql` once on existing
deployments; fresh databases get the column from `create_all`.
